### PR TITLE
filled out auth.js util

### DIFF
--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,0 +1,41 @@
+const { GraphQLError } = require("graphql");
+const jwt = require("jsonwebtoken");
+
+const secret = "mysecretssshhhhhhh";
+const expiration = "2h";
+
+module.exports = {
+  AuthenticationError: new GraphQLError("Could not authenticate user.", {
+    extensions: {
+      code: "UNAUTHENTICATED",
+    },
+  }),
+  authMiddleware: function ({ req }) {
+    let token = req.body.token || req.query.token || req.headers.authorization;
+
+    if (req.headers.authorization) {
+      token = token.split(" ").pop().trim();
+    }
+
+    if (!token) {
+      return req;
+    }
+
+    try {
+      const { authenticatedPerson } = jwt.verify(token, secret, {
+        maxAge: expiration,
+      });
+      req.user = authenticatedPerson;
+    } catch {
+      console.log("Invalid token");
+    }
+
+    return req;
+  },
+  signToken: function ({ email, username, _id }) {
+    const payload = { email, username, _id };
+    return jwt.sign({ authenticatedPerson: payload }, secret, {
+      expiresIn: expiration,
+    });
+  },
+};


### PR DESCRIPTION
Purpose

Initialized jwt functionality

Fixes #[3]
Changes

Filled out the auth.js util helper, to be used in other files.

Steps to Reproduce or Test

Can be tested in other files by calling: import Auth from '../../utils/auth';
